### PR TITLE
Missing dummies for everything under the sun

### DIFF
--- a/code/census/3_census_merge.do
+++ b/code/census/3_census_merge.do
@@ -192,23 +192,33 @@ gen commuters = B09001_002 + B09001_003 + B09001_004 + B09001_005 + B09001_006 +
 gen commuters_zip_percent_under = (B09001_002 + B09001_003 + B09001_004 + B09001_005) / commuters // PERCENTAGE UNDER 40 MIN
 gen commuters_zip_percent_over = (B09001_006 + B09001_007 + B09001_008) / commuters // PERCENTAGE OVER 40 MIN
 
-gen commute_time_city_percent_under = 0 
+gen commute_city_percent_under = 0 
 forvalues city = 1/7{
 	sum commuters_zip_percent_under if cleaned_city == `city'
-	replace commute_time_city_percent_under = (commuters_zip_percent_under - `r(mean)') / `r(sd)' 
+	replace commute_city_percent_under = (commuters_zip_percent_under - `r(mean)') / `r(sd)' 
 }
 
-gen commute_time_city_percent_over = 0 
+gen commute_city_percent_over = 0 
 forvalues city = 1/7{
 	sum commuters_zip_percent_over if cleaned_city == `city'
-	replace commute_time_city_percent_over = (commuters_zip_percent_over - `r(mean)') / `r(sd)' 
+	replace commute_city_percent_over = (commuters_zip_percent_over - `r(mean)') / `r(sd)' 
 }
 
 
 ********************************************************************************
 * STEP 5: GENERAL MERGE
 
-keep zipcode cleaned_city popdensity med_value med_gross_rent med_income_city_norm race_white_city_norm race_black_city_norm race_asian_city_norm race_sor_city_norm race_hnom_city_norm unemployed_city_percent HHSSI_city_percent occupied_city_percent commute_time_city_percent_under commute_time_city_percent_over
+keep zipcode cleaned_city popdensity med_value med_gross_rent med_income_city_norm race_white_city_norm race_black_city_norm race_asian_city_norm race_sor_city_norm race_hnom_city_norm unemployed_city_percent HHSSI_city_percent occupied_city_percent commute_city_percent_under commute_city_percent_over
+
+
+***CREATING MISSING INDICATORS
+local ncat popdensity med_value med_gross_rent med_income_city_norm race_white_city_norm race_black_city_norm race_asian_city_norm race_sor_city_norm race_hnom_city_norm unemployed_city_percent HHSSI_city_percent occupied_city_percent commute_city_percent_under commute_city_percent_over
+foreach var in `ncat'{
+	gen miss_`var' = 0
+	replace miss_`var' = 1 if `var'== .
+	sum `var'
+	replace `var' = `r(mean)' if `var'== .
+}
 
 save "$repository/code/census/census.dta", replace
 

--- a/code/main/2_city_specific_clean.do
+++ b/code/main/2_city_specific_clean.do
@@ -136,5 +136,37 @@ neighborhood_overview_subject)
 ;
 #delimit cr
 
+rename neighborhood_overview_polarity neighborhood_polarity
+rename neighborhood_overview_subject neighborhood_subjectivity
+
+** Renaming just for creating missing dummies
+rename group_neighbourhood_cleansed group_nhood_clean
+rename require_guest_profile_picture req_guest_pro_pic
+rename require_guest_phone_verification req_guest_phone
+
+** Create more indicator variables for missing variables 
+local varlist race_sex_res group_ra_name cleaned_city group_nhood_clean group_property_type group_room_type accommodates bathrooms bedrooms beds group_bed_type cleaning_fee extra_people num_amenities group_cancellation_policy instant_bookable req_guest_pro_pic req_guest_phone minimum_nights availability_30 availability_60 
+
+foreach var in `varlist'{
+	gen miss_`var' = 0
+	replace miss_`var' = 1 if `var'== .
+	replace `var' = 0 if `var'== .
+}
+
+rename group_nhood_clean group_neighbourhood_cleansed
+rename req_guest_pro_pic require_guest_profile_picture
+rename req_guest_phone require_guest_phone_verification
+
+
+** Creating missing dummies for NLP
+local NLP summary_polarity summary_subjectivity description_polarity description_subjectivity space_polarity space_subjectivity reviews_polarity reviews_subjectivity neighborhood_polarity neighborhood_subjectivity
+
+foreach var in `NLP'{
+	gen miss_`var' = 0
+	replace miss_`var' = 1 if `var'== .
+	sum `var'
+	replace `var' = `r(mean)' if `var'== .
+}
+
 ** Exporting for census merging
 save "$repository/code/census/cleaned.dta", replace

--- a/code/tables/10_robustness_listing_chars.do
+++ b/code/tables/10_robustness_listing_chars.do
@@ -21,8 +21,8 @@ quietly reg log_price
 			availability_30 availability_60 
 			summary_polarity summary_subjectivity 
 			space_polarity space_subjectivity description_polarity description_subjectivity 
-			neighborhood_overview_polarity 
-			neighborhood_overview_subject //Quality of listing/effort of host
+			neighborhood_polarity 
+			neighborhood_subjectivity//Quality of listing/effort of host
 			i.group_host_response_time miss_group_host_response_time 
 			host_response_rate //Host-specific charac.
 			host_identity_verified host_is_superhost 
@@ -48,8 +48,8 @@ quietly reg log_price
 			availability_30 availability_60
 			summary_polarity summary_subjectivity 
 			space_polarity space_subjectivity description_polarity description_subjectivity 
-			neighborhood_overview_polarity 
-			neighborhood_overview_subject  //Quality of listing/effort of host
+			neighborhood_polarity 
+			neighborhood_subjectivity //Quality of listing/effort of host
 			i.group_host_response_time miss_group_host_response_time 
 			host_response_rate //Host-specific charac.
 			host_identity_verified host_is_superhost
@@ -75,8 +75,8 @@ quietly reg log_price
 			availability_30 availability_60 
 			reviews_polarity reviews_subjectivity summary_polarity summary_subjectivity 
 			space_polarity space_subjectivity description_polarity description_subjectivity 
-			neighborhood_overview_polarity 
-			neighborhood_overview_subject  //Quality of listing/effort of host
+			neighborhood_polarity 
+			neighborhood_subjectivity //Quality of listing/effort of host
 			i.group_host_response_time miss_group_host_response_time
 			host_response_rate  //Host-specific charac.
 			host_identity_verified host_is_superhost 
@@ -102,8 +102,8 @@ quietly reg log_price i.race_res
 			availability_30 availability_60 
 			summary_polarity summary_subjectivity 
 			space_polarity space_subjectivity description_polarity description_subjectivity 
-			neighborhood_overview_polarity 
-			neighborhood_overview_subject  //Quality of listing/effort of host
+			neighborhood_polarity 
+			neighborhood_subjectivity //Quality of listing/effort of host
 			i.group_host_response_time miss_group_host_response_time
 			host_response_rate //Host-specific charac.
 			host_identity_verified host_is_superhost 
@@ -126,8 +126,8 @@ quietly reg log_price i.race_res
 			availability_30 availability_60 
 			summary_polarity summary_subjectivity 
 			space_polarity space_subjectivity description_polarity description_subjectivity 
-			neighborhood_overview_polarity 
-			neighborhood_overview_subject //Quality of listing/effort of host
+			neighborhood_polarity 
+			neighborhood_subjectivity//Quality of listing/effort of host
 			i.group_host_response_time miss_group_host_response_time
 			host_response_rate //Host-specific charac.
 			host_identity_verified host_is_superhost 
@@ -150,8 +150,8 @@ quietly reg log_price i.race_res
 			availability_30 availability_60
 			summary_polarity summary_subjectivity 
 			space_polarity space_subjectivity description_polarity description_subjectivity 
-			neighborhood_overview_polarity 
-			neighborhood_overview_subject  //Quality of listing/effort of host
+			neighborhood_polarity 
+			neighborhood_subjectivity //Quality of listing/effort of host
 			i.group_host_response_time miss_group_host_response_time 
 			host_response_rate  //Host-specific charac.
 			host_identity_verified host_is_superhost 
@@ -174,8 +174,8 @@ quietly reg log_price i.race_res
 			availability_30 availability_60
 			summary_polarity summary_subjectivity 
 			space_polarity space_subjectivity description_polarity description_subjectivity 
-			neighborhood_overview_polarity 
-			neighborhood_overview_subject  //Quality of listing/effort of host
+			neighborhood_polarity 
+			neighborhood_subjectivity //Quality of listing/effort of host
 			i.group_host_response_time miss_group_host_response_time 
 			host_response_rate //Host-specific charac.
 			host_identity_verified host_is_superhost 
@@ -198,8 +198,8 @@ quietly reg log_price i.race_res
 			availability_30 availability_60
 			reviews_polarity reviews_subjectivity summary_polarity summary_subjectivity 
 			space_polarity space_subjectivity description_polarity description_subjectivity 
-			neighborhood_overview_polarity 
-			neighborhood_overview_subject  //Quality of listing/effort of host
+			neighborhood_polarity 
+			neighborhood_subjectivity //Quality of listing/effort of host
 			i.group_host_response_time miss_group_host_response_time 
 			host_response_rate //Host-specific charac.
 			host_identity_verified host_is_superhost 
@@ -221,8 +221,8 @@ eststo model5
 			availability_30 availability_60
 			reviews_polarity reviews_subjectivity summary_polarity summary_subjectivity 
 			space_polarity space_subjectivity description_polarity description_subjectivity 
-			neighborhood_overview_polarity 
-			neighborhood_overview_subject  //Quality of listing/effort of host
+			neighborhood_polarity 
+			neighborhood_subjectivity //Quality of listing/effort of host
 			i.group_host_response_time miss_group_host_response_time 
 			host_response_rate //Host-specific charac.
 			host_identity_verified host_is_superhost 
@@ -244,8 +244,8 @@ quietly reg log_price i.race_res
 			availability_30 availability_60
 			reviews_polarity reviews_subjectivity summary_polarity summary_subjectivity 
 			space_polarity space_subjectivity description_polarity description_subjectivity 
-			neighborhood_overview_polarity 
-			neighborhood_overview_subject  //Quality of listing/effort of host
+			neighborhood_polarity 
+			neighborhood_subjectivity //Quality of listing/effort of host
 			i.group_host_response_time miss_group_host_response_time 
 			host_response_rate //Host-specific charac.
 			host_identity_verified host_is_superhost 
@@ -268,8 +268,8 @@ quietly reg log_price i.race_res
 			availability_30 availability_60 
 			reviews_polarity reviews_subjectivity summary_polarity summary_subjectivity 
 			space_polarity space_subjectivity description_polarity description_subjectivity 
-			neighborhood_overview_polarity 
-			neighborhood_overview_subject  //Quality of listing/effort of host
+			neighborhood_polarity 
+			neighborhood_subjectivity //Quality of listing/effort of host
 			i.group_host_response_time miss_group_host_response_time 
 			host_response_rate //Host-specific charac.
 			host_identity_verified host_is_superhost 
@@ -293,8 +293,8 @@ quietly reg log_price i.race_res
 			availability_30 availability_60
 			reviews_polarity reviews_subjectivity summary_polarity summary_subjectivity 
 			space_polarity space_subjectivity description_polarity description_subjectivity 
-			neighborhood_overview_polarity 
-			neighborhood_overview_subject  //Quality of listing/effort of host
+			neighborhood_polarity 
+			neighborhood_subjectivity //Quality of listing/effort of host
 			i.group_host_response_time miss_group_host_response_time
 			host_response_rate //Host-specific charac.
 			host_identity_verified host_is_superhost 
@@ -318,8 +318,8 @@ quietly reg log_price i.race_res
 			availability_30 availability_60
 			reviews_polarity reviews_subjectivity summary_polarity summary_subjectivity 
 			space_polarity space_subjectivity description_polarity description_subjectivity 
-			neighborhood_overview_polarity 
-			neighborhood_overview_subject  //Quality of listing/effort of host
+			neighborhood_polarity 
+			neighborhood_subjectivity //Quality of listing/effort of host
 			i.group_host_response_time miss_group_host_response_time 
 			host_response_rate //Host-specific charac.
 			host_identity_verified host_is_superhost 
@@ -343,8 +343,8 @@ quietly reg log_price i.race_res
 			availability_30 availability_60
 			reviews_polarity reviews_subjectivity summary_polarity summary_subjectivity 
 			space_polarity space_subjectivity description_polarity description_subjectivity 
-			neighborhood_overview_polarity 
-			neighborhood_overview_subject  //Quality of listing/effort of host
+			neighborhood_polarity 
+			neighborhood_subjectivity //Quality of listing/effort of host
 			i.group_host_response_time miss_group_host_response_time 
 			host_response_rate //Host-specific charac.
 			host_identity_verified host_is_superhost 

--- a/code/tables/12_revenue.do
+++ b/code/tables/12_revenue.do
@@ -52,8 +52,8 @@ quietly reg p_year_reviews i.race_sex_res i.age
 			availability_30 availability_60
 			reviews_polarity reviews_subjectivity summary_polarity summary_subjectivity 
 			space_polarity space_subjectivity description_polarity description_subjectivity 
-			neighborhood_overview_polarity 
-			neighborhood_overview_subject  //Quality of listing/effort of host
+			neighborhood_polarity 
+			neighborhood_subjectivity  //Quality of listing/effort of host
 			i.group_host_response_time miss_group_host_response_time 
 			host_response_rate //Host-specific charac.
 			host_identity_verified host_is_superhost,  //Host-specific charac.

--- a/code/tables/5_price.do
+++ b/code/tables/5_price.do
@@ -49,11 +49,33 @@ quietly reg log_price i.race_sex_res i.age i.group_ra_name
 			availability_30 availability_60 
 			reviews_polarity reviews_subjectivity summary_polarity summary_subjectivity 
 			space_polarity space_subjectivity description_polarity description_subjectivity 
-			neighborhood_overview_polarity 
-			neighborhood_overview_subject  //Quality of listing/effort of host
+			neighborhood_polarity 
+			neighborhood_subjectivity  //Quality of listing/effort of host
 			i.group_host_response_time miss_group_host_response_time 
 			host_response_rate //Host-specific charac.
-			host_identity_verified host_is_superhost,
+			host_identity_verified host_is_superhost
+			miss_age miss_race_sex_res miss_group_ra_name // Missing indicators
+			miss_cleaned_city miss_group_property_type 
+			miss_group_room_type miss_accommodates miss_bathrooms miss_bedrooms 
+			miss_beds miss_group_bed_type miss_cleaning_fee miss_extra_people 
+			miss_num_amenities miss_group_cancellation_policy 
+			miss_instant_bookable miss_req_guest_pro_pic
+			miss_req_guest_phone miss_minimum_nights miss_availability_30 
+			miss_availability_60 
+			miss_group_nhood_clean
+			popdensity med_value med_gross_rent med_income_city_norm race_white_city_norm // Census variables
+			race_black_city_norm race_asian_city_norm race_sor_city_norm race_hnom_city_norm
+			unemployed_city_percent HHSSI_city_percent occupied_city_percent commute_city_percent_under
+			commute_city_percent_over 
+			miss_popdensity // Census missing dummies
+			miss_med_value miss_med_gross_rent miss_med_income_city_norm miss_race_white_city_norm 
+			miss_race_black_city_norm miss_race_asian_city_norm miss_race_sor_city_norm miss_race_hnom_city_norm
+			miss_unemployed_city_percent miss_HHSSI_city_percent miss_occupied_city_percent miss_commute_city_percent_under
+			miss_commute_city_percent_over 
+			miss_reviews_polarity miss_reviews_subjectivity miss_summary_polarity // NLP missing dummies
+			miss_summary_subjectivity miss_space_polarity miss_space_subjectivity miss_description_polarity 
+			miss_description_subjectivity miss_neighborhood_polarity miss_neighborhood_subjectivity 
+			,
 			vce(cluster group_neighbourhood_cleansed) 
 ;
 #delimit cr

--- a/code/tables/7_number_reviews.do
+++ b/code/tables/7_number_reviews.do
@@ -50,8 +50,8 @@ quietly reg log_number_of_reviews i.race_sex_res i.age
 			availability_30 availability_60 reviews_polarity reviews_subjectivity 
 			summary_polarity summary_subjectivity 
 			space_polarity space_subjectivity description_polarity description_subjectivity 
-			neighborhood_overview_polarity 
-			neighborhood_overview_subject //Quality of listing/effort of host
+			neighborhood_polarity 
+			neighborhood_subjectivity //Quality of listing/effort of host
 			i.group_host_response_time miss_group_host_response_time 
 			host_response_rate //Host-specific charac.
 			host_identity_verified host_is_superhost, //Host-specific charac.

--- a/code/tables/8_availability_30.do
+++ b/code/tables/8_availability_30.do
@@ -16,8 +16,8 @@ reg availability_30 i.race_sex_res
 			require_guest_phone_verification minimum_nights
 			reviews_polarity reviews_subjectivity summary_polarity summary_subjectivity 
 			space_polarity space_subjectivity description_polarity description_subjectivity 
-			neighborhood_overview_polarity 
-			neighborhood_overview_subject //Quality of listing/effort of host
+			neighborhood_polarity 
+			neighborhood_subjectivity //Quality of listing/effort of host
 			i.group_host_response_time miss_group_host_response_time 
 			host_response_rate //Host-specific charac.
 			host_identity_verified host_is_superhost,  //Host-specific charac.

--- a/code/tables/9_robustness_city.do
+++ b/code/tables/9_robustness_city.do
@@ -22,8 +22,8 @@ quietly reg log_price i.race_res
 			availability_30 availability_60 
 			summary_polarity summary_subjectivity 
 			space_polarity space_subjectivity description_polarity description_subjectivity 
-			neighborhood_overview_polarity 
-			neighborhood_overview_subject //Quality of listing/effort of host
+			neighborhood_polarity 
+			neighborhood_subjectivity //Quality of listing/effort of host
 			i.group_host_response_time miss_group_host_response_time host_response_rate //Host-specific charac.
 			host_identity_verified host_is_superhost 
 				if state == "CA", //Host-specific charac.
@@ -44,8 +44,8 @@ quietly reg log_price i.race_res
 			availability_30 availability_60
 			summary_polarity summary_subjectivity 
 			space_polarity space_subjectivity description_polarity description_subjectivity 
-			neighborhood_overview_polarity 
-			neighborhood_overview_subject //Quality of listing/effort of host
+			neighborhood_polarity 
+			neighborhood_subjectivity //Quality of listing/effort of host
 			i.group_host_response_time miss_group_host_response_time host_response_rate //Host-specific charac.
 			host_identity_verified host_is_superhost
 				if state == "NY", //Host-specific charac.
@@ -67,8 +67,8 @@ quietly reg log_price i.race_res
 			availability_30 availability_60
 			summary_polarity summary_subjectivity 
 			space_polarity space_subjectivity description_polarity description_subjectivity 
-			neighborhood_overview_polarity 
-			neighborhood_overview_subject //Quality of listing/effort of host
+			neighborhood_polarity 
+			neighborhood_subjectivity //Quality of listing/effort of host
 			i.group_host_response_time miss_group_host_response_time 
 			host_response_rate //Host-specific charac.
 			host_identity_verified host_is_superhost
@@ -92,8 +92,8 @@ quietly reg log_price i.race_res
 			availability_30 availability_60
 			reviews_polarity reviews_subjectivity summary_polarity summary_subjectivity 
 			space_polarity space_subjectivity description_polarity description_subjectivity 
-			neighborhood_overview_polarity 
-			neighborhood_overview_subject //Quality of listing/effort of host
+			neighborhood_polarity 
+			neighborhood_subjectivity //Quality of listing/effort of host
 			i.group_host_response_time miss_group_host_response_time 
 			host_response_rate //Host-specific charac.
 			host_identity_verified host_is_superhost
@@ -116,8 +116,8 @@ quietly reg log_price i.race_res
 			availability_30 availability_60 
 			summary_polarity summary_subjectivity 
 			space_polarity space_subjectivity description_polarity description_subjectivity 
-			neighborhood_overview_polarity 
-			neighborhood_overview_subject //Quality of listing/effort of host
+			neighborhood_polarity 
+			neighborhood_subjectivity //Quality of listing/effort of host
 			i.group_host_response_time miss_group_host_response_time 
 			host_response_rate //Host-specific charac.
 			host_identity_verified host_is_superhost
@@ -140,8 +140,8 @@ quietly reg log_price i.race_res
 			availability_30 availability_60 
 			summary_polarity summary_subjectivity 
 			space_polarity space_subjectivity description_polarity description_subjectivity 
-			neighborhood_overview_polarity 
-			neighborhood_overview_subject //Quality of listing/effort of host
+			neighborhood_polarity 
+			neighborhood_subjectivity //Quality of listing/effort of host
 			i.group_host_response_time miss_group_host_response_time
 			host_response_rate //Host-specific charac.
 			host_identity_verified host_is_superhost
@@ -164,8 +164,8 @@ quietly reg log_price i.race_res
 			availability_30 availability_60 
 			summary_polarity summary_subjectivity 
 			space_polarity space_subjectivity description_polarity description_subjectivity 
-			neighborhood_overview_polarity 
-			neighborhood_overview_subject //Quality of listing/effort of host
+			neighborhood_polarity 
+			neighborhood_subjectivity //Quality of listing/effort of host
 			i.group_host_response_time miss_group_host_response_time 
 			host_response_rate //Host-specific charac.
 			host_identity_verified host_is_superhost


### PR DESCRIPTION
DONE:
(1) Created missing dummies for census, NLP, final specificiation variables.
(2) Some variable names too long for Stata's liking:
[a] renamed/shortened "neighborhood_overview_polarity" and "..._subject" to "neighborhood_polarity" and "neighborhood_subjectivity"
[b] renamed "commute_time_..." to "commute..."
(3) Added census variables, missing census indicators, missing NLP indicators, and missing other variable indicators to MODEL 4 in PRICE.DO